### PR TITLE
fix broken build and test (couple of problems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Please Star & Watch this project if it's of any interest or use to you!
     cd ch.vorburger.minecraft.osgi
     git submodule update --init --recursive
     cd ch.vorburger.osgi.gradle
-    ./gradlew install
+    ./gradlew install test
     cd ..
-    ./gradlew install
+    ./gradlew install test
 
 NB: You must use `install` and not just `build` _(because the MinecraftOSGiTest fails otherwise)._
 
@@ -82,7 +82,7 @@ The `minecraft.osgi.users` which we just installed above makes it easy to now de
 
 3. Connect your Minecraft client to this local server
 
-4. In game, you should hvae just been greeted with a `HELO` message followed by `.. will install ..`.  This chat message is issued by `minecraft.osgi.users` on join.  More importantly, it has created a new development project for you under the `dev/` directory (which you created above).  The project is under a sub-directory with your player's Minecraft UUID.
+4. In game, you should have just been greeted with a `HELO` message followed by `.. will install ..`.  This chat message is issued by `minecraft.osgi.users` on join.  More importantly, it has created a new development project for you under the `dev/` directory (which you created above).  The project is under a sub-directory with your player's Minecraft UUID.
 
 5. Open this new dev project in your favourite Java IDE (like e.g. [Eclipse](https://eclipse.org/downloads/), or IntelliJ's IDEA).  Note that this project uses Gradle for dependency management, so you must have Gradle support in your IDE (e.g. the latest Eclipse version Oxygen already includes [Buildship](https://projects.eclipse.org/projects/tools.buildship)).  (Gradle is also used to produced a valid OSGi MANIFEST.MF for the JAR, via [BND](http://bnd.bndtools.org).)
 
@@ -101,6 +101,9 @@ The `minecraft.osgi.users` which we just installed above makes it easy to now de
 The `/osgi:install <URI>` command, where _URI_ is typically a `file:/` prefixed path to an OSGi bundle JAR file, or a directory to a Gradle project, installs (and, if it's a directory, continuously builds and HOT reloads) that OSGi bundle.  This lets you work with projects outside of your `dev/<User-UUID>/project1` directory.
 
 The `osgi/installedBundles` file lists all so installed bundles.  What is listed here is started on server boot, after those in the `osgi/system` directory.  You can edit this file, and e.g. remove the example `dev/<User-UUID>/project1` from here.
+
+When using it like this, you do not need to copy the `osgi.templates` and `osgi.users` (but all the other ones listed above).
+
 ## What else?
 
 The `ch.vorburger.minecraft.news` and `ch.vorburger.minecraft.worlds` are two example OSGi mods which you don't need to write your own, but can have a look at, and could also optionally install into `osgi/boot` (with boot order prefix `6_...`) if you like.

--- a/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/BundleManager.java
+++ b/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/BundleManager.java
@@ -20,7 +20,7 @@ package ch.vorburger.minecraft.osgi.dev;
 
 import ch.vorburger.minecraft.utils.CommandExceptions;
 import ch.vorburger.minecraft.utils.MessageReceivers;
-import ch.vorburger.osgi.gradle.SourceInstallService;
+import ch.vorburger.osgi.builder.SourceInstallService;
 import java.io.File;
 import java.net.URI;
 import org.spongepowered.api.command.CommandException;
@@ -60,7 +60,7 @@ public class BundleManager {
         File bundleFile = new File(bundleURI);
         installBundle(commandSource, bundleFile);
     }
-    // public void installBundle(User user, String bundleURI) {
+    // public void installBundle(User user, URI bundleURI) {
 
     // TODO keep bundle running when user logs out, or stop?
     public void installBundle(User user, File bundleFileOrDirectory) {

--- a/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/BundleManagerPersistence.java
+++ b/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/BundleManagerPersistence.java
@@ -19,7 +19,7 @@
 package ch.vorburger.minecraft.osgi.dev;
 
 import ch.vorburger.minecraft.utils.LoggingFutureCallback;
-import ch.vorburger.osgi.gradle.SourceInstallService;
+import ch.vorburger.osgi.builder.SourceInstallService;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.Futures;

--- a/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/internal/Activator.java
+++ b/ch.vorburger.minecraft.osgi.dev/src/main/java/ch/vorburger/minecraft/osgi/dev/internal/Activator.java
@@ -21,7 +21,7 @@ package ch.vorburger.minecraft.osgi.dev.internal;
 import ch.vorburger.minecraft.osgi.api.CommandRegistration;
 import ch.vorburger.minecraft.osgi.dev.BundleManager;
 import ch.vorburger.minecraft.osgi.dev.commands.InstallCommand;
-import ch.vorburger.osgi.gradle.SourceInstallService;
+import ch.vorburger.osgi.builder.SourceInstallService;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;

--- a/ch.vorburger.minecraft.osgi.templates/src/test/java/ch/vorburger/minecraft/osgi/templates/tests/SimpleProjectTemplateGenerateAndBuildTest.java
+++ b/ch.vorburger.minecraft.osgi.templates/src/test/java/ch/vorburger/minecraft/osgi/templates/tests/SimpleProjectTemplateGenerateAndBuildTest.java
@@ -21,8 +21,8 @@ package ch.vorburger.minecraft.osgi.templates.tests;
 import ch.vorburger.minecraft.osgi.templates.ProjectTemplate;
 import ch.vorburger.minecraft.osgi.templates.ProjectWriter;
 import ch.vorburger.minecraft.osgi.templates.SimpleProjectTemplate;
-import ch.vorburger.osgi.gradle.internal.BuildService;
-import ch.vorburger.osgi.gradle.internal.BuildServiceImpl;
+import ch.vorburger.osgi.builder.gradle.internal.GradleBuildService;
+import ch.vorburger.osgi.builder.internal.BuildService;
 import com.google.common.io.Files;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +37,7 @@ public class SimpleProjectTemplateGenerateAndBuildTest {
         File testTemplateProjectBaseDir = Files.createTempDir();
         try {
             new ProjectWriter().writeProject(template, testTemplateProjectBaseDir);
-            try (BuildService bs = new BuildServiceImpl()) {
+            try (BuildService bs = new GradleBuildService()) {
                 bs.build(testTemplateProjectBaseDir, "build").get(1, TimeUnit.MINUTES);
             }
         } finally {

--- a/ch.vorburger.minecraft.osgi/src/main/java/ch/vorburger/minecraft/osgi/Bootstrap.java
+++ b/ch.vorburger.minecraft.osgi/src/main/java/ch/vorburger/minecraft/osgi/Bootstrap.java
@@ -18,6 +18,8 @@
  */
 package ch.vorburger.minecraft.osgi;
 
+import static java.util.Objects.requireNonNull;
+
 import ch.vorburger.minecraft.osgi.api.PluginInstance;
 import ch.vorburger.minecraft.osgi.api.impl.ApiImplBootstrap;
 import ch.vorburger.osgi.utils.BundleInstaller;
@@ -34,7 +36,8 @@ public class Bootstrap {
     // TODO find a better name for this class and the factory method
 
     public static BundleInstaller bootstrapMinecraftOSGi(String osgiBasePath, PluginInstance pluginInstance) throws IOException, BundleException {
-        File osgiBaseDirectory = new File(osgiBasePath);
+        requireNonNull(pluginInstance, "pluginInstance == null");
+        File osgiBaseDirectory = new File(requireNonNull(osgiBasePath, "osgiBasePath == null"));
         OSGiFrameworkWrapper osgiFramework = new OSGiFrameworkWrapper(osgiBaseDirectory);
         Bundle systemBundle = osgiFramework.start();
         BundleContext bundleContext = systemBundle.getBundleContext();

--- a/ch.vorburger.minecraft.osgi/src/test/java/ch/vorburger/minecraft/osgi/tests/MinecraftOSGiTest.java
+++ b/ch.vorburger.minecraft.osgi/src/test/java/ch/vorburger/minecraft/osgi/tests/MinecraftOSGiTest.java
@@ -34,7 +34,7 @@ public class MinecraftOSGiTest {
 
     @Test
     public void testMain() throws Exception {
-        BundleInstaller osgiFramework = Bootstrap.bootstrapMinecraftOSGi("target/testOsgiFramework", null);
+        BundleInstaller osgiFramework = Bootstrap.bootstrapMinecraftOSGi("target/testOsgiFramework", () -> null);
 
         List<Bundle> bundles = osgiFramework.installBundles("file:../ch.vorburger.minecraft.osgi.testplugin/build/libs/ch.vorburger.minecraft.osgi.testplugin-1.0.0-SNAPSHOT.jar");
         Bundle testPluginBundle = bundles.get(0);


### PR DESCRIPTION
1. use the new SourceInstallService from ch.vorburger.osgi.builder
instead of the @Deprecated (but identical) one from the gradle package;
we deprecated the interface in the gradle package when we introduced the
support for Maven based builds.

2. SimpleProjectTemplateGenerateAndBuildTest new GradleBuildService()
instead of new BuildServiceImpl() which does not exist anymore,
following the refactoring

3. fix NPE in MinecraftOSGiTest (unrelated to Maven support in
ch.vorburger.osgi.gradle; that seems to have been broken long ago, but
only shows on "./gradlew install test" not just "./gradlew install")